### PR TITLE
Fix: Sanitize file output in search results to prevent XSS

### DIFF
--- a/search.php
+++ b/search.php
@@ -108,11 +108,7 @@ include 'templates/sidebar.php';
                                         <td><?= htmlspecialchars(substr($row['URAIAN'] ?? '', 0, 100)) ?>...</td>
                                         <td><?= htmlspecialchars($row['TAHUN'] ?? '') ?></td>
                                         <td>
-                                            <?php if (strpos($row['FILE'], '<a') !== false): ?>
-                                                <?= $row['FILE'] ?>
-                                            <?php else: ?>
-                                                <?= htmlspecialchars($row['FILE'] ?? '') ?>
-                                            <?php endif; ?>
+                                            <?= htmlspecialchars($row['FILE'] ?? '') ?>
                                         </td>
                                         <?php if ($auth->isAdmin()): ?>
                                         <td>


### PR DESCRIPTION
This commit addresses a cross-site scripting (XSS) vulnerability in the search results page. The `FILE` field from the database was being rendered without proper output encoding, which could allow malicious scripts to be executed in a user's browser.

The fix removes the conditional check that allowed raw HTML and applies `htmlspecialchars()` to the `FILE` field in all cases. This ensures that any potentially malicious code is displayed as plain text rather than being executed by the browser.